### PR TITLE
fix(ci): auto-enable github pages for registry deploy

### DIFF
--- a/.github/workflows/deploy-registry.yml
+++ b/.github/workflows/deploy-registry.yml
@@ -35,6 +35,8 @@ jobs:
       - run: touch apps/registry/public/.nojekyll
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: apps/registry/public


### PR DESCRIPTION
## Summary
- fix GitHub Pages deploy bootstrap for new repos
- set `enablement: true` on `actions/configure-pages@v5` so the workflow can auto-enable Pages on first run

## Why
The first `Deploy Registry` run failed with `Get Pages site failed ... Not Found` because Pages had not been enabled yet.
