### PR TITLE
fix(ci): make registry deploy skip when pages disabled

### DIFF
--- a/.github/workflows/deploy-registry.yml
+++ b/.github/workflows/deploy-registry.yml
@@ -34,11 +34,33 @@ jobs:
       - run: pnpm run build:registry
       - run: touch apps/registry/public/.nojekyll
 
-      - uses: actions/configure-pages@v5
+      - id: pages
+        uses: actions/github-script@v7
         with:
-          enablement: true
+          script: |
+            try {
+              await github.request("GET /repos/{owner}/{repo}/pages", {
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              core.setOutput("enabled", "true");
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning("GitHub Pages is not enabled for this repository. Enable Pages once in repository settings to activate deployment.");
+                core.setOutput("enabled", "false");
+                return;
+              }
+              throw error;
+            }
+
+      - uses: actions/configure-pages@v5
+        if: steps.pages.outputs.enabled == 'true'
+        with:
+          enablement: false
       - uses: actions/upload-pages-artifact@v3
+        if: steps.pages.outputs.enabled == 'true'
         with:
           path: apps/registry/public
       - id: deployment
         uses: actions/deploy-pages@v4
+        if: steps.pages.outputs.enabled == 'true'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ After changesets are merged into `main`, GitHub Actions will:
 - Target URL (GitHub Pages): `https://curiousbus.github.io/frontend-template-blocks/`
 - Registry entrypoint: `https://curiousbus.github.io/frontend-template-blocks/registry.json`
 - Example item URL: `https://curiousbus.github.io/frontend-template-blocks/r/simple-hero.json`
+- One-time setup: enable GitHub Pages in repo settings (`Settings -> Pages`) and select GitHub Actions as the source.
 
 ## Install From Registry (after deployment)
 ```bash


### PR DESCRIPTION
## Summary
- make `Deploy Registry` workflow non-blocking when GitHub Pages is not enabled yet
- detect Pages availability with `actions/github-script`
- skip configure/upload/deploy steps when Pages is disabled and emit clear warning
- document one-time Pages setup in README

## Why
`GITHUB_TOKEN` in this repository cannot create a Pages site automatically (`Resource not accessible by integration`).
This change prevents deployment workflow failures on `main` while keeping deployment active once Pages is enabled.
