### PR TITLE
docs(web): add registry homepage and consumer usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,25 @@ After changesets are merged into `main`, GitHub Actions will:
 - Example item URL: `https://curiousbus.github.io/frontend-template-blocks/r/simple-hero.json`
 - One-time setup: enable GitHub Pages in repo settings (`Settings -> Pages`) and select GitHub Actions as the source.
 
-## Install From Registry (after deployment)
+## Use This Registry (Consumer Guide)
+1. Initialize shadcn in your project (if you have not done it yet).
+2. Install a block by item URL:
+
 ```bash
-shadcn add <registry-url>/r/simple-hero.json
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/simple-hero.json
 ```
+
+3. Swap the item filename to install other blocks:
+
+```bash
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/feature-grid.json
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/pricing-cards.json
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/testimonial-wall.json
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/stats-strip.json
+shadcn add https://curiousbus.github.io/frontend-template-blocks/r/cta-banner.json
+```
+
+4. Browse available links from the homepage: `https://curiousbus.github.io/frontend-template-blocks/`
 
 ## Current Phase
 Phase 1 scaffold from issue #1 + issue #6:

--- a/apps/registry/public/index.html
+++ b/apps/registry/public/index.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend Template Blocks Registry</title>
+    <style>
+      :root {
+        --bg: #f5f2ea;
+        --panel: #fffdf8;
+        --ink: #1f1f1f;
+        --muted: #5a5a5a;
+        --accent: #0f7a68;
+        --accent-ink: #e8fff8;
+        --line: #dcd6ca;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Avenir Next", "Helvetica Neue", Helvetica, sans-serif;
+        color: var(--ink);
+        background:
+          radial-gradient(circle at 15% 10%, #d9f2ea 0%, transparent 42%),
+          radial-gradient(circle at 85% 5%, #f9e6d3 0%, transparent 38%),
+          var(--bg);
+        min-height: 100vh;
+      }
+
+      .shell {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 24px 64px;
+      }
+
+      .hero {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        padding: 28px;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.06);
+      }
+
+      .label {
+        display: inline-block;
+        background: #111;
+        color: #fff;
+        font-size: 12px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 7px 10px;
+        border-radius: 999px;
+      }
+
+      h1 {
+        margin: 18px 0 8px;
+        font-family: Georgia, "Times New Roman", serif;
+        font-size: clamp(34px, 6vw, 56px);
+        line-height: 1.05;
+        letter-spacing: -0.02em;
+      }
+
+      p {
+        margin: 0;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      .grid {
+        margin-top: 24px;
+        display: grid;
+        gap: 20px;
+      }
+
+      @media (min-width: 960px) {
+        .grid {
+          grid-template-columns: 1.2fr 1fr;
+        }
+      }
+
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        padding: 20px;
+      }
+
+      .card h2 {
+        margin: 0 0 12px;
+        font-size: 18px;
+      }
+
+      .command {
+        margin-top: 12px;
+        background: #131313;
+        color: #f3f3f3;
+        border-radius: 12px;
+        padding: 12px;
+        font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+        font-size: 13px;
+        overflow-x: auto;
+      }
+
+      .toolbar {
+        margin-top: 12px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      button,
+      .link {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 10px 14px;
+        background: #fff;
+        color: var(--ink);
+        text-decoration: none;
+        font-size: 14px;
+        cursor: pointer;
+      }
+
+      button.primary,
+      .link.primary {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--accent-ink);
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 10px;
+      }
+
+      li a {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 10px;
+        padding: 12px;
+        border-radius: 12px;
+        background: #fff;
+        border: 1px solid var(--line);
+        color: inherit;
+        text-decoration: none;
+      }
+
+      li a span {
+        color: var(--muted);
+        font-size: 13px;
+        font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+      }
+
+      .footer {
+        margin-top: 22px;
+        font-size: 13px;
+        color: var(--muted);
+      }
+
+      .footer code {
+        font-family: "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <div class="label">Shadcn Registry</div>
+        <h1>Frontend Template Blocks</h1>
+        <p>
+          This site hosts installable registry JSON for reusable blocks. Use the command below in any initialized
+          shadcn project.
+        </p>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Install One Block</h2>
+          <p>Use a direct item URL.</p>
+          <pre class="command" id="install-cmd">shadcn add https://curiousbus.github.io/frontend-template-blocks/r/simple-hero.json</pre>
+          <div class="toolbar">
+            <button class="primary" id="copy-btn" type="button">Copy Command</button>
+            <a class="link" href="/frontend-template-blocks/registry.json">Open registry.json</a>
+          </div>
+        </article>
+
+        <article class="card">
+          <h2>Available Blocks</h2>
+          <ul>
+            <li><a href="/frontend-template-blocks/r/simple-hero.json">Simple Hero <span>r/simple-hero.json</span></a></li>
+            <li><a href="/frontend-template-blocks/r/feature-grid.json">Feature Grid <span>r/feature-grid.json</span></a></li>
+            <li><a href="/frontend-template-blocks/r/pricing-cards.json">Pricing Cards <span>r/pricing-cards.json</span></a></li>
+            <li><a href="/frontend-template-blocks/r/testimonial-wall.json">Testimonial Wall <span>r/testimonial-wall.json</span></a></li>
+            <li><a href="/frontend-template-blocks/r/stats-strip.json">Stats Strip <span>r/stats-strip.json</span></a></li>
+            <li><a href="/frontend-template-blocks/r/cta-banner.json">CTA Banner <span>r/cta-banner.json</span></a></li>
+          </ul>
+        </article>
+      </section>
+
+      <p class="footer">
+        Repository: <a href="https://github.com/curiousbus/frontend-template-blocks">curiousbus/frontend-template-blocks</a>
+        <br />
+        Build and deploy are automated by GitHub Actions from <code>apps/registry/public</code>.
+      </p>
+    </main>
+
+    <script>
+      const copyBtn = document.getElementById("copy-btn");
+      const installCmd = document.getElementById("install-cmd").textContent;
+
+      copyBtn?.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(installCmd);
+          copyBtn.textContent = "Copied";
+          setTimeout(() => {
+            copyBtn.textContent = "Copy Command";
+          }, 1500);
+        } catch {
+          copyBtn.textContent = "Copy Failed";
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a proper landing page at `apps/registry/public/index.html` so the Pages root URL no longer appears broken
- list available block endpoints and direct install command on the homepage
- add copy-to-clipboard action for install command
- update README with explicit consumer usage steps and direct install commands

## Validation
- `pnpm run build:registry`

Refs #8
