### PR TITLE
feat: add comprehensive shadcn-style saas backoffice blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ shadcn add https://curiousbus.github.io/curious-ui/r/sidebar-navigation.json
 shadcn add https://curiousbus.github.io/curious-ui/r/auth-sign-in.json
 shadcn add https://curiousbus.github.io/curious-ui/r/auth-sign-up.json
 shadcn add https://curiousbus.github.io/curious-ui/r/data-table.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-kpi-grid.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-command-center.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-billing-overview.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-team-roster.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-notification-inbox.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-audit-timeline.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-integrations-grid.json
+shadcn add https://curiousbus.github.io/curious-ui/r/saas-settings-sections.json
 ```
 
 3. Discover all items:
@@ -290,3 +298,7 @@ export function UsersTable() {
   );
 }
 ```
+
+## SaaS Backoffice Block Pack
+- Includes KPI, command center, billing overview, team roster, notification inbox, audit timeline, integrations grid, and settings sections.
+- Architecture + interaction design notes: `docs/saas-backoffice-block-system-design.md`

--- a/docs/saas-backoffice-block-system-design.md
+++ b/docs/saas-backoffice-block-system-design.md
@@ -1,0 +1,112 @@
+# SaaS Backoffice Block System Design
+
+Issue: #41
+
+## 1. Product Context
+
+SaaS backoffice systems need to support:
+- operations teams (billing, support, incident triage)
+- growth teams (retention, segmentation, experiments)
+- security/compliance teams (auditability, least privilege, policy rollout)
+- workspace admins (team lifecycle, integrations, settings)
+
+Design goals:
+- composable blocks instead of page-locked templates
+- shadcn-compatible visual language
+- quick scanning density with strong hierarchy
+- performance-safe motion and interaction feedback
+
+## 2. Block Taxonomy
+
+### Core analytics and decision blocks
+- `saas-kpi-grid`: executive snapshot metrics and trends
+
+### Workflow acceleration blocks
+- `saas-command-center`: searchable command launcher for repeated admin actions
+
+### Revenue and plan governance blocks
+- `saas-billing-overview`: plan, renewal, usage, invoice summary
+
+### Access and lifecycle blocks
+- `saas-team-roster`: member status, role, and security posture overview
+
+### Event triage and observability blocks
+- `saas-notification-inbox`: category-filtered event inbox
+- `saas-audit-timeline`: chronological sensitive-action record
+
+### Ecosystem expansion blocks
+- `saas-integrations-grid`: catalog and status for external providers
+
+### Configuration governance blocks
+- `saas-settings-sections`: grouped settings readiness and progress
+
+## 3. API and Composition Principles
+
+Each block follows these rules:
+- data-in / callback-out architecture
+- no hardcoded transport assumptions
+- serializable props for server/client boundaries
+- default-safe visual behavior with optional customization
+
+Examples:
+- command center accepts `actions[]` and emits `onActionSelect`
+- team roster accepts `members[]` and emits `onMemberClick`
+- integrations grid accepts `integrations[]` and emits `onConnect` / `onConfigure`
+
+## 4. Interaction Model
+
+- low-friction controls at block level (search, filter, segmented toggles)
+- actions are placed nearest to the relevant entity row/card
+- empty states include explicit next-step language
+- all icon-only controls have explicit labels
+
+## 5. Motion and Performance Strategy
+
+Motion rules:
+- entrance and feedback use transform/opacity only
+- interaction feedback stays short and subtle
+- reduced-motion users skip non-essential transitions
+
+Performance rules:
+- memoize expensive derived lists (`useMemo`) where filtering/grouping is present
+- avoid repeated layout measurements and scroll polling
+- avoid heavyweight visual effects on large surfaces
+
+## 6. Visual Language Alignment (shadcn)
+
+- uses tokenized classes: `bg-card`, `border-input`, `text-muted-foreground`
+- standard radius, spacing, border hierarchy
+- action affordances match shadcn button/input sizing rhythm
+- no custom design system divergence in color semantics
+
+## 7. Delivered Artifacts
+
+Source components:
+- `packages/blocks/src/saas-kpi-grid.tsx`
+- `packages/blocks/src/saas-command-center.tsx`
+- `packages/blocks/src/saas-billing-overview.tsx`
+- `packages/blocks/src/saas-team-roster.tsx`
+- `packages/blocks/src/saas-notification-inbox.tsx`
+- `packages/blocks/src/saas-audit-timeline.tsx`
+- `packages/blocks/src/saas-integrations-grid.tsx`
+- `packages/blocks/src/saas-settings-sections.tsx`
+
+Stories:
+- `packages/blocks/src/stories/saas-kpi-grid.stories.jsx`
+- `packages/blocks/src/stories/saas-command-center.stories.jsx`
+- `packages/blocks/src/stories/saas-billing-overview.stories.jsx`
+- `packages/blocks/src/stories/saas-team-roster.stories.jsx`
+- `packages/blocks/src/stories/saas-notification-inbox.stories.jsx`
+- `packages/blocks/src/stories/saas-audit-timeline.stories.jsx`
+- `packages/blocks/src/stories/saas-integrations-grid.stories.jsx`
+- `packages/blocks/src/stories/saas-settings-sections.stories.jsx`
+
+Registry items:
+- `packages/blocks/registry/saas-kpi-grid.json`
+- `packages/blocks/registry/saas-command-center.json`
+- `packages/blocks/registry/saas-billing-overview.json`
+- `packages/blocks/registry/saas-team-roster.json`
+- `packages/blocks/registry/saas-notification-inbox.json`
+- `packages/blocks/registry/saas-audit-timeline.json`
+- `packages/blocks/registry/saas-integrations-grid.json`
+- `packages/blocks/registry/saas-settings-sections.json`

--- a/packages/blocks/registry/saas-audit-timeline.json
+++ b/packages/blocks/registry/saas-audit-timeline.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-audit-timeline",
+  "type": "registry:block",
+  "title": "SaaS Audit Timeline",
+  "description": "Chronological audit event timeline for security and compliance visibility.",
+  "meta": {
+    "category": "security",
+    "a11y": "Ordered timeline semantics and contrast-safe severity indicators."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-audit-timeline.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-audit-timeline.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-billing-overview.json
+++ b/packages/blocks/registry/saas-billing-overview.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-billing-overview",
+  "type": "registry:block",
+  "title": "SaaS Billing Overview",
+  "description": "Plan, invoice, and usage overview panel for subscription SaaS admin consoles.",
+  "meta": {
+    "category": "billing",
+    "a11y": "Readable billing summary and usage progress with text alternatives."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-billing-overview.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-billing-overview.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-command-center.json
+++ b/packages/blocks/registry/saas-command-center.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-command-center",
+  "type": "registry:block",
+  "title": "SaaS Command Center",
+  "description": "Searchable command launcher for common backoffice actions and admin workflows.",
+  "meta": {
+    "category": "operations",
+    "a11y": "Keyboard-focusable command buttons and labeled command search field."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-command-center.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-command-center.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-integrations-grid.json
+++ b/packages/blocks/registry/saas-integrations-grid.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-integrations-grid",
+  "type": "registry:block",
+  "title": "SaaS Integrations Grid",
+  "description": "Integration catalog cards for connecting and configuring SaaS ecosystem tools.",
+  "meta": {
+    "category": "integrations",
+    "a11y": "Clear action buttons and text labels for integration states."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-integrations-grid.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-integrations-grid.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-kpi-grid.json
+++ b/packages/blocks/registry/saas-kpi-grid.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-kpi-grid",
+  "type": "registry:block",
+  "title": "SaaS KPI Grid",
+  "description": "Analytics KPI cards for SaaS dashboards with trend indicators and sparklines.",
+  "meta": {
+    "category": "analytics",
+    "a11y": "Semantic section headings and numeric values with tabular alignment."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-kpi-grid.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-kpi-grid.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-notification-inbox.json
+++ b/packages/blocks/registry/saas-notification-inbox.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-notification-inbox",
+  "type": "registry:block",
+  "title": "SaaS Notification Inbox",
+  "description": "Filtered operations inbox for SaaS notifications, incidents, and billing events.",
+  "meta": {
+    "category": "operations",
+    "a11y": "Filter controls and clear read state labels for notification triage."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-notification-inbox.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-notification-inbox.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-settings-sections.json
+++ b/packages/blocks/registry/saas-settings-sections.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-settings-sections",
+  "type": "registry:block",
+  "title": "SaaS Settings Sections",
+  "description": "Structured settings overview cards for identity, security, and workspace configuration.",
+  "meta": {
+    "category": "settings",
+    "a11y": "Section labels and status indicators with keyboard-accessible actions."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-settings-sections.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-settings-sections.tsx"
+    }
+  ]
+}

--- a/packages/blocks/registry/saas-team-roster.json
+++ b/packages/blocks/registry/saas-team-roster.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "saas-team-roster",
+  "type": "registry:block",
+  "title": "SaaS Team Roster",
+  "description": "Team access roster for member lifecycle, role, and security coverage.",
+  "meta": {
+    "category": "team-management",
+    "a11y": "Accessible team actions and status labels for user lifecycle state."
+  },
+  "dependencies": ["motion"],
+  "registryDependencies": [],
+  "files": [
+    {
+      "path": "src/saas-team-roster.tsx",
+      "type": "registry:component",
+      "target": "components/blocks/saas-team-roster.tsx"
+    }
+  ]
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -55,6 +55,30 @@ export {
   TrashIcon,
 } from "./data-table";
 export { HeroSplit } from "./hero-split";
+export type { SaasAuditEvent, SaasAuditSeverity } from "./saas-audit-timeline";
+export { SaasAuditTimeline } from "./saas-audit-timeline";
+export type { SaasInvoiceSummary, SaasUsageItem } from "./saas-billing-overview";
+export { SaasBillingOverview } from "./saas-billing-overview";
+export type { SaasCommandAction } from "./saas-command-center";
+export { ActionIcon as SaasCommandActionIcon, SaasCommandCenter } from "./saas-command-center";
+export type { SaasIntegration, SaasIntegrationStatus } from "./saas-integrations-grid";
+export {
+  IntegrationIcon as SaasIntegrationIcon,
+  SaasIntegrationsGrid,
+} from "./saas-integrations-grid";
+export type { SaasKpiMetric, SaasKpiTone, SaasKpiTrend } from "./saas-kpi-grid";
+export {
+  SaasKpiGrid,
+  TrendDownIcon as SaasTrendDownIcon,
+  TrendFlatIcon as SaasTrendFlatIcon,
+  TrendUpIcon as SaasTrendUpIcon,
+} from "./saas-kpi-grid";
+export type { SaasNotification, SaasNotificationPriority } from "./saas-notification-inbox";
+export { SaasNotificationInbox } from "./saas-notification-inbox";
+export type { SaasSettingSection, SaasSettingSectionStatus } from "./saas-settings-sections";
+export { SaasSettingsSections } from "./saas-settings-sections";
+export type { SaasMemberStatus, SaasTeamMember } from "./saas-team-roster";
+export { SaasTeamRoster } from "./saas-team-roster";
 export type { SidebarNavGroup, SidebarNavItem } from "./sidebar-navigation";
 export {
   SidebarNavCollapseTrigger,

--- a/packages/blocks/src/saas-audit-timeline.tsx
+++ b/packages/blocks/src/saas-audit-timeline.tsx
@@ -1,0 +1,97 @@
+import { motion, useReducedMotion } from "motion/react";
+import type * as React from "react";
+
+export type SaasAuditSeverity = "info" | "warning" | "critical";
+
+export type SaasAuditEvent = {
+  id: string;
+  actor: string;
+  action: string;
+  target: string;
+  time: string;
+  severity?: SaasAuditSeverity;
+  metadata?: Array<{ label: string; value: string }>;
+};
+
+type SaasAuditTimelineProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  events: SaasAuditEvent[];
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function severityClass(severity: SaasAuditSeverity | undefined) {
+  if (severity === "critical") {
+    return "bg-destructive";
+  }
+  if (severity === "warning") {
+    return "bg-amber-500";
+  }
+  return "bg-emerald-600";
+}
+
+export function SaasAuditTimeline({
+  title = "Audit Timeline",
+  description = "Track sensitive actions with actor context, resource scope, and event metadata.",
+  events,
+  className,
+  ...props
+}: SaasAuditTimelineProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <ol className="mt-4 space-y-3">
+        {events.map((event, index) => (
+          <motion.li
+            key={event.id}
+            className="grid grid-cols-[16px,1fr] gap-3"
+            initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+            animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+            transition={
+              shouldReduceMotion
+                ? undefined
+                : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+            }
+          >
+            <div className="flex h-full flex-col items-center">
+              <span className={cn("mt-1 size-2 rounded-full", severityClass(event.severity))} />
+              {index < events.length - 1 ? <span className="mt-1 h-full w-px bg-border" /> : null}
+            </div>
+
+            <article className="rounded-lg border bg-background p-3">
+              <p className="text-sm font-medium">
+                <span>{event.actor}</span>
+                <span className="text-muted-foreground"> {event.action} </span>
+                <span>{event.target}</span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{event.time}</p>
+
+              {event.metadata && event.metadata.length > 0 ? (
+                <dl className="mt-2 grid gap-1 sm:grid-cols-2">
+                  {event.metadata.map((item) => (
+                    <div
+                      key={`${event.id}-${item.label}`}
+                      className="rounded border bg-muted/40 px-2 py-1"
+                    >
+                      <dt className="text-[11px] text-muted-foreground">{item.label}</dt>
+                      <dd className="truncate text-xs text-foreground">{item.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+            </article>
+          </motion.li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/packages/blocks/src/saas-billing-overview.tsx
+++ b/packages/blocks/src/saas-billing-overview.tsx
@@ -1,0 +1,185 @@
+import { motion, useReducedMotion } from "motion/react";
+import type * as React from "react";
+
+export type SaasUsageItem = {
+  id: string;
+  label: string;
+  used: number;
+  limit: number;
+  unit?: string;
+};
+
+export type SaasInvoiceSummary = {
+  subtotal: number;
+  discount?: number;
+  tax?: number;
+  total: number;
+  currency?: string;
+};
+
+type SaasBillingOverviewProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  planName: string;
+  monthlyPrice: number;
+  currency?: string;
+  renewalDate: string;
+  usage: SaasUsageItem[];
+  invoice?: SaasInvoiceSummary;
+  ctaLabel?: string;
+  onCtaClick?: () => void;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function formatMoney(value: number, currency = "USD") {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function progressValue(used: number, limit: number) {
+  if (limit <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, (used / limit) * 100));
+}
+
+function usageTone(percent: number) {
+  if (percent >= 90) {
+    return "bg-destructive";
+  }
+  if (percent >= 70) {
+    return "bg-amber-500";
+  }
+  return "bg-emerald-600";
+}
+
+export function SaasBillingOverview({
+  title = "Billing & Usage",
+  description = "Track your active plan, renewal date, and operational usage limits.",
+  planName,
+  monthlyPrice,
+  currency = "USD",
+  renewalDate,
+  usage,
+  invoice,
+  ctaLabel = "Manage billing",
+  onCtaClick,
+  className,
+  ...props
+}: SaasBillingOverviewProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold text-balance">{title}</h2>
+          <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+        </header>
+
+        <button
+          type="button"
+          className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium transition-colors hover:bg-accent"
+          onClick={onCtaClick}
+        >
+          {ctaLabel}
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-[1.2fr,1fr]">
+        <article className="rounded-lg border bg-background p-4">
+          <p className="text-sm text-muted-foreground">Current plan</p>
+          <p className="mt-1 text-xl font-semibold text-balance">{planName}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <p>
+              <span className="font-medium text-foreground tabular-nums">
+                {formatMoney(monthlyPrice, currency)}
+              </span>{" "}
+              / month
+            </p>
+            <p>Renews on {renewalDate}</p>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {usage.map((item, index) => {
+              const percent = progressValue(item.used, item.limit);
+
+              return (
+                <motion.div
+                  key={item.id}
+                  className="space-y-1"
+                  initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+                  animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+                  transition={
+                    shouldReduceMotion
+                      ? undefined
+                      : { duration: 0.2, ease: "easeOut", delay: index * 0.03 }
+                  }
+                >
+                  <div className="flex items-center justify-between gap-2 text-xs">
+                    <p className="text-muted-foreground">{item.label}</p>
+                    <p className="text-foreground tabular-nums">
+                      {item.used}
+                      {item.unit ? ` ${item.unit}` : ""} / {item.limit}
+                      {item.unit ? ` ${item.unit}` : ""}
+                    </p>
+                  </div>
+
+                  <div className="h-2 overflow-hidden rounded-full bg-muted">
+                    <motion.div
+                      className={cn("h-full rounded-full", usageTone(percent))}
+                      initial={shouldReduceMotion ? undefined : { scaleX: 0 }}
+                      animate={shouldReduceMotion ? undefined : { scaleX: percent / 100 }}
+                      transition={
+                        shouldReduceMotion
+                          ? undefined
+                          : { duration: 0.22, ease: "easeOut", delay: index * 0.02 }
+                      }
+                      style={{ transformOrigin: "left center" }}
+                    />
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </article>
+
+        <article className="rounded-lg border bg-background p-4">
+          <p className="text-sm font-medium">Invoice summary</p>
+
+          {invoice ? (
+            <dl className="mt-3 space-y-2 text-sm tabular-nums">
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Subtotal</dt>
+                <dd>{formatMoney(invoice.subtotal, invoice.currency ?? currency)}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Discount</dt>
+                <dd>{formatMoney(invoice.discount ?? 0, invoice.currency ?? currency)}</dd>
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Tax</dt>
+                <dd>{formatMoney(invoice.tax ?? 0, invoice.currency ?? currency)}</dd>
+              </div>
+              <div className="my-1 border-t" />
+              <div className="flex items-center justify-between gap-2 text-base font-semibold">
+                <dt>Total</dt>
+                <dd>{formatMoney(invoice.total, invoice.currency ?? currency)}</dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="mt-2 text-sm text-muted-foreground text-pretty">
+              Add invoice details to show a full breakdown for finance and procurement.
+            </p>
+          )}
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/packages/blocks/src/saas-command-center.tsx
+++ b/packages/blocks/src/saas-command-center.tsx
@@ -1,0 +1,229 @@
+import { motion, useReducedMotion } from "motion/react";
+import * as React from "react";
+
+export type SaasCommandAction = {
+  id: string;
+  title: string;
+  description?: string;
+  group?: string;
+  shortcut?: string;
+  badge?: string;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  onSelect?: (id: string) => void | Promise<void>;
+};
+
+type SaasCommandCenterProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  placeholder?: string;
+  actions: SaasCommandAction[];
+  defaultQuery?: string;
+  onActionSelect?: (actionId: string) => void | Promise<void>;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function normalizeText(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function SaasCommandCenter({
+  title = "Command Center",
+  description = "Launch common SaaS admin actions in a single surface.",
+  placeholder = "Search command, member, billing, integration...",
+  actions,
+  defaultQuery = "",
+  onActionSelect,
+  className,
+  ...props
+}: SaasCommandCenterProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const [query, setQuery] = React.useState(defaultQuery);
+  const [pendingId, setPendingId] = React.useState<string | null>(null);
+
+  const normalizedQuery = normalizeText(query);
+
+  const filteredActions = React.useMemo(() => {
+    if (!normalizedQuery) {
+      return actions;
+    }
+
+    return actions.filter((action) => {
+      return [action.title, action.description ?? "", action.group ?? "", action.shortcut ?? ""]
+        .join(" ")
+        .toLowerCase()
+        .includes(normalizedQuery);
+    });
+  }, [actions, normalizedQuery]);
+
+  const groupedActions = React.useMemo(() => {
+    const groups = new Map<string, SaasCommandAction[]>();
+
+    for (const action of filteredActions) {
+      const group = action.group ?? "General";
+      const existing = groups.get(group);
+      if (existing) {
+        existing.push(action);
+      } else {
+        groups.set(group, [action]);
+      }
+    }
+
+    return Array.from(groups.entries());
+  }, [filteredActions]);
+
+  const handleSelect = async (action: SaasCommandAction) => {
+    if (action.disabled) {
+      return;
+    }
+
+    const result = action.onSelect?.(action.id);
+    if (result && typeof (result as Promise<void>).then === "function") {
+      setPendingId(action.id);
+      try {
+        await result;
+      } finally {
+        setPendingId(null);
+      }
+    }
+
+    void onActionSelect?.(action.id);
+  };
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <div className="mt-4 rounded-lg border bg-background p-2">
+        <label htmlFor="saas-command-search" className="sr-only">
+          Search commands
+        </label>
+        <div className="relative">
+          <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            id="saas-command-search"
+            type="search"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+            }}
+            placeholder={placeholder}
+            className="h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm shadow-xs outline-none transition focus-visible:ring-1 focus-visible:ring-ring"
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {groupedActions.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm font-medium">No command found</p>
+            <p className="mt-1 text-sm text-muted-foreground text-pretty">
+              Try a broader keyword such as billing, members, or integration.
+            </p>
+          </div>
+        ) : (
+          groupedActions.map(([group, groupActions]) => (
+            <div key={group} className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">{group}</p>
+              <div className="space-y-2">
+                {groupActions.map((action, index) => {
+                  const isPending = pendingId === action.id;
+
+                  return (
+                    <motion.button
+                      key={action.id}
+                      type="button"
+                      onClick={() => {
+                        void handleSelect(action);
+                      }}
+                      disabled={action.disabled || isPending}
+                      className="flex w-full items-center gap-3 rounded-lg border bg-background px-3 py-2 text-left transition-colors hover:bg-accent/60 disabled:opacity-60"
+                      initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+                      animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+                      transition={
+                        shouldReduceMotion
+                          ? undefined
+                          : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+                      }
+                      whileHover={shouldReduceMotion ? undefined : { y: -1 }}
+                      whileTap={shouldReduceMotion ? undefined : { scale: 0.995 }}
+                    >
+                      <span className="text-muted-foreground">
+                        {action.icon ?? <ActionIcon className="size-4" />}
+                      </span>
+
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-2">
+                          <span className="truncate text-sm font-medium">{action.title}</span>
+                          {action.badge ? (
+                            <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground tabular-nums">
+                              {action.badge}
+                            </span>
+                          ) : null}
+                        </span>
+                        {action.description ? (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {action.description}
+                          </span>
+                        ) : null}
+                      </span>
+
+                      {action.shortcut ? (
+                        <kbd className="rounded border bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground tabular-nums">
+                          {action.shortcut}
+                        </kbd>
+                      ) : null}
+                    </motion.button>
+                  );
+                })}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+type IconProps = React.ComponentPropsWithoutRef<"svg">;
+
+export function SearchIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.5-3.5" />
+    </svg>
+  );
+}
+
+export function ActionIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="4" y="4" width="16" height="16" rx="2" />
+      <path d="M8 9h8" />
+      <path d="M8 13h6" />
+    </svg>
+  );
+}

--- a/packages/blocks/src/saas-integrations-grid.tsx
+++ b/packages/blocks/src/saas-integrations-grid.tsx
@@ -1,0 +1,143 @@
+import { motion, useReducedMotion } from "motion/react";
+import type * as React from "react";
+
+export type SaasIntegrationStatus = "connected" | "available" | "beta";
+
+export type SaasIntegration = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  status?: SaasIntegrationStatus;
+  icon?: React.ReactNode;
+  metric?: string;
+};
+
+type SaasIntegrationsGridProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  integrations: SaasIntegration[];
+  onConnect?: (integration: SaasIntegration) => void;
+  onConfigure?: (integration: SaasIntegration) => void;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function statusClass(status: SaasIntegrationStatus | undefined) {
+  if (status === "connected") {
+    return "bg-emerald-500/10 text-emerald-700";
+  }
+  if (status === "beta") {
+    return "bg-amber-500/10 text-amber-700";
+  }
+  return "bg-muted text-muted-foreground";
+}
+
+export function SaasIntegrationsGrid({
+  title = "Integrations",
+  description = "Connect payments, CRM, support, and data stack providers into your SaaS operations.",
+  integrations,
+  onConnect,
+  onConfigure,
+  className,
+  ...props
+}: SaasIntegrationsGridProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className={cn("space-y-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {integrations.map((integration, index) => {
+          const isConnected = integration.status === "connected";
+
+          return (
+            <motion.article
+              key={integration.id}
+              className="rounded-lg border bg-card p-4"
+              initial={shouldReduceMotion ? undefined : { opacity: 0, y: 8 }}
+              animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+              transition={
+                shouldReduceMotion
+                  ? undefined
+                  : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+              }
+              whileHover={shouldReduceMotion ? undefined : { y: -2 }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex size-8 items-center justify-center rounded-md border bg-background text-muted-foreground">
+                    {integration.icon ?? <IntegrationIcon className="size-4" />}
+                  </span>
+                  <div>
+                    <p className="text-sm font-medium">{integration.name}</p>
+                    <p className="text-xs text-muted-foreground">{integration.category}</p>
+                  </div>
+                </div>
+
+                <span
+                  className={cn(
+                    "rounded px-1.5 py-0.5 text-[11px]",
+                    statusClass(integration.status),
+                  )}
+                >
+                  {integration.status ?? "available"}
+                </span>
+              </div>
+
+              <p className="mt-3 text-sm text-muted-foreground text-pretty">
+                {integration.description}
+              </p>
+
+              <div className="mt-3 flex items-center justify-between gap-2">
+                <p className="text-xs text-muted-foreground tabular-nums">
+                  {integration.metric ?? "No sync yet"}
+                </p>
+                <button
+                  type="button"
+                  className="inline-flex h-8 items-center rounded-md border border-input bg-background px-2 text-xs font-medium transition-colors hover:bg-accent"
+                  onClick={() => {
+                    if (isConnected) {
+                      onConfigure?.(integration);
+                    } else {
+                      onConnect?.(integration);
+                    }
+                  }}
+                >
+                  {isConnected ? "Configure" : "Connect"}
+                </button>
+              </div>
+            </motion.article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+type IconProps = React.ComponentPropsWithoutRef<"svg">;
+
+export function IntegrationIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </svg>
+  );
+}

--- a/packages/blocks/src/saas-kpi-grid.tsx
+++ b/packages/blocks/src/saas-kpi-grid.tsx
@@ -1,0 +1,225 @@
+import { motion, useReducedMotion } from "motion/react";
+import * as React from "react";
+
+export type SaasKpiTone = "default" | "success" | "warning" | "danger";
+
+export type SaasKpiTrend = {
+  value: string;
+  direction?: "up" | "down" | "flat";
+  label?: string;
+};
+
+export type SaasKpiMetric = {
+  id: string;
+  label: string;
+  value: string;
+  helper?: string;
+  trend?: SaasKpiTrend;
+  tone?: SaasKpiTone;
+  icon?: React.ReactNode;
+  sparkline?: number[];
+};
+
+type SaasKpiGridProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  metrics: SaasKpiMetric[];
+  columns?: 2 | 3 | 4;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function toneClass(tone: SaasKpiTone | undefined) {
+  if (tone === "success") {
+    return "text-emerald-700";
+  }
+
+  if (tone === "warning") {
+    return "text-amber-700";
+  }
+
+  if (tone === "danger") {
+    return "text-destructive";
+  }
+
+  return "text-foreground";
+}
+
+function trendIcon(direction: SaasKpiTrend["direction"]) {
+  if (direction === "up") {
+    return <TrendUpIcon className="size-3.5" />;
+  }
+  if (direction === "down") {
+    return <TrendDownIcon className="size-3.5" />;
+  }
+  return <TrendFlatIcon className="size-3.5" />;
+}
+
+function gridColumnClass(columns: SaasKpiGridProps["columns"]) {
+  if (columns === 2) {
+    return "md:grid-cols-2";
+  }
+  if (columns === 3) {
+    return "md:grid-cols-2 xl:grid-cols-3";
+  }
+  return "md:grid-cols-2 xl:grid-cols-4";
+}
+
+function toSparklinePath(points: number[]) {
+  if (points.length < 2) {
+    return "";
+  }
+
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const range = max - min || 1;
+
+  return points
+    .map((point, index) => {
+      const x = (index / (points.length - 1)) * 100;
+      const y = 100 - ((point - min) / range) * 100;
+      return `${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+function Sparkline({ points }: { points: number[] }) {
+  const path = React.useMemo(() => toSparklinePath(points), [points]);
+
+  if (!path) {
+    return null;
+  }
+
+  return (
+    <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="h-8 w-20" aria-hidden="true">
+      <path d={path} fill="none" stroke="currentColor" strokeWidth="7" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function SaasKpiGrid({
+  title = "Business Snapshot",
+  description = "Core SaaS metrics your team checks every day.",
+  metrics,
+  columns = 4,
+  className,
+  ...props
+}: SaasKpiGridProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className={cn("space-y-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <div className={cn("grid gap-3", gridColumnClass(columns))}>
+        {metrics.map((metric, index) => (
+          <motion.article
+            key={metric.id}
+            className="rounded-lg border bg-card p-4 shadow-sm"
+            initial={shouldReduceMotion ? undefined : { opacity: 0, y: 8 }}
+            animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+            transition={
+              shouldReduceMotion
+                ? undefined
+                : { duration: 0.2, ease: "easeOut", delay: index * 0.03 }
+            }
+            whileHover={shouldReduceMotion ? undefined : { y: -2 }}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-muted-foreground">{metric.label}</p>
+              {metric.icon ? <span className="text-muted-foreground">{metric.icon}</span> : null}
+            </div>
+
+            <div className="mt-2 flex items-end justify-between gap-3">
+              <p className={cn("text-2xl font-semibold tabular-nums", toneClass(metric.tone))}>
+                {metric.value}
+              </p>
+              {metric.sparkline && metric.sparkline.length > 1 ? (
+                <div className="text-muted-foreground">
+                  <Sparkline points={metric.sparkline} />
+                </div>
+              ) : null}
+            </div>
+
+            <div className="mt-2 flex items-center justify-between gap-2">
+              {metric.trend ? (
+                <p className={cn("inline-flex items-center gap-1 text-xs", toneClass(metric.tone))}>
+                  {trendIcon(metric.trend.direction)}
+                  <span className="tabular-nums">{metric.trend.value}</span>
+                  {metric.trend.label ? (
+                    <span className="text-muted-foreground">{metric.trend.label}</span>
+                  ) : null}
+                </p>
+              ) : (
+                <span />
+              )}
+
+              {metric.helper ? (
+                <p className="text-xs text-muted-foreground text-pretty">{metric.helper}</p>
+              ) : null}
+            </div>
+          </motion.article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+type IconProps = React.ComponentPropsWithoutRef<"svg">;
+
+export function TrendUpIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4 14 10 8l4 4 6-6" />
+      <path d="M20 6h-4" />
+      <path d="M20 6v4" />
+    </svg>
+  );
+}
+
+export function TrendDownIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4 10 10 16l4-4 6 6" />
+      <path d="M20 18h-4" />
+      <path d="M20 18v-4" />
+    </svg>
+  );
+}
+
+export function TrendFlatIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4 12h16" />
+    </svg>
+  );
+}

--- a/packages/blocks/src/saas-notification-inbox.tsx
+++ b/packages/blocks/src/saas-notification-inbox.tsx
@@ -1,0 +1,210 @@
+import { motion, useReducedMotion } from "motion/react";
+import * as React from "react";
+
+export type SaasNotificationPriority = "low" | "normal" | "high";
+
+export type SaasNotification = {
+  id: string;
+  title: string;
+  body: string;
+  category?: string;
+  time: string;
+  isRead?: boolean;
+  priority?: SaasNotificationPriority;
+};
+
+type SaasNotificationInboxProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  notifications: SaasNotification[];
+  categories?: string[];
+  onOpenNotification?: (notification: SaasNotification) => void;
+  onMarkAsRead?: (notification: SaasNotification) => void;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function priorityDotClass(priority: SaasNotificationPriority | undefined) {
+  if (priority === "high") {
+    return "bg-destructive";
+  }
+
+  if (priority === "low") {
+    return "bg-emerald-600";
+  }
+
+  return "bg-amber-500";
+}
+
+export function SaasNotificationInbox({
+  title = "Notification Inbox",
+  description = "Triage user, billing, and reliability events with fast context.",
+  notifications,
+  categories,
+  onOpenNotification,
+  onMarkAsRead,
+  className,
+  ...props
+}: SaasNotificationInboxProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const [tab, setTab] = React.useState<"all" | "unread">("all");
+  const [activeCategory, setActiveCategory] = React.useState<string>("all");
+
+  const categoryOptions = React.useMemo(() => {
+    const base = new Set(categories ?? []);
+
+    for (const notification of notifications) {
+      if (notification.category) {
+        base.add(notification.category);
+      }
+    }
+
+    return ["all", ...Array.from(base)];
+  }, [categories, notifications]);
+
+  const filteredNotifications = React.useMemo(() => {
+    return notifications.filter((notification) => {
+      if (tab === "unread" && notification.isRead) {
+        return false;
+      }
+
+      if (activeCategory !== "all" && notification.category !== activeCategory) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [activeCategory, notifications, tab]);
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <SegmentButton label="All" active={tab === "all"} onClick={() => setTab("all")} />
+        <SegmentButton label="Unread" active={tab === "unread"} onClick={() => setTab("unread")} />
+
+        <div className="ml-auto">
+          <label htmlFor="saas-notification-category" className="sr-only">
+            Notification category
+          </label>
+          <select
+            id="saas-notification-category"
+            className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+            value={activeCategory}
+            onChange={(event) => {
+              setActiveCategory(event.target.value);
+            }}
+          >
+            {categoryOptions.map((option) => (
+              <option key={option} value={option}>
+                {option === "all" ? "All categories" : option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {filteredNotifications.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm font-medium">Inbox is clear</p>
+            <p className="mt-1 text-sm text-muted-foreground text-pretty">
+              No notifications match the current filters.
+            </p>
+          </div>
+        ) : (
+          filteredNotifications.map((notification, index) => (
+            <motion.article
+              key={notification.id}
+              className="rounded-lg border bg-background p-3"
+              initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+              animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+              transition={
+                shouldReduceMotion
+                  ? undefined
+                  : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+              }
+            >
+              <div className="flex items-start gap-3">
+                <span
+                  className={cn(
+                    "mt-1 size-2 rounded-full",
+                    priorityDotClass(notification.priority),
+                  )}
+                />
+
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="truncate text-sm font-medium">{notification.title}</p>
+                    {notification.category ? (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                        {notification.category}
+                      </span>
+                    ) : null}
+                    {!notification.isRead ? (
+                      <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[11px] text-primary">
+                        New
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="text-sm text-muted-foreground text-pretty">{notification.body}</p>
+                  <p className="text-xs text-muted-foreground">{notification.time}</p>
+                </div>
+
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className="inline-flex h-8 items-center rounded-md border border-input bg-background px-2 text-xs font-medium transition-colors hover:bg-accent"
+                    onClick={() => onOpenNotification?.(notification)}
+                  >
+                    Open
+                  </button>
+                  {!notification.isRead ? (
+                    <button
+                      type="button"
+                      className="inline-flex h-8 items-center rounded-md border border-input bg-background px-2 text-xs font-medium transition-colors hover:bg-accent"
+                      onClick={() => onMarkAsRead?.(notification)}
+                    >
+                      Mark read
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </motion.article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SegmentButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex h-8 items-center rounded-md border px-2 text-xs font-medium transition-colors",
+        active
+          ? "border-primary/30 bg-primary/10 text-primary"
+          : "border-input bg-background text-muted-foreground hover:bg-accent",
+      )}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/blocks/src/saas-settings-sections.tsx
+++ b/packages/blocks/src/saas-settings-sections.tsx
@@ -1,0 +1,105 @@
+import { motion, useReducedMotion } from "motion/react";
+import type * as React from "react";
+
+export type SaasSettingSectionStatus = "complete" | "attention" | "draft";
+
+export type SaasSettingSection = {
+  id: string;
+  title: string;
+  description: string;
+  status?: SaasSettingSectionStatus;
+  items?: Array<{ label: string; value: string }>;
+};
+
+type SaasSettingsSectionsProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  sections: SaasSettingSection[];
+  onOpenSection?: (section: SaasSettingSection) => void;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function statusClass(status: SaasSettingSectionStatus | undefined) {
+  if (status === "complete") {
+    return "bg-emerald-500/10 text-emerald-700";
+  }
+  if (status === "attention") {
+    return "bg-amber-500/10 text-amber-700";
+  }
+  return "bg-muted text-muted-foreground";
+}
+
+export function SaasSettingsSections({
+  title = "Settings Workspace",
+  description = "Organize security, identity, notifications, and workspace controls by section.",
+  sections,
+  onOpenSection,
+  className,
+  ...props
+}: SaasSettingsSectionsProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold text-balance">{title}</h2>
+        <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+      </header>
+
+      <div className="mt-4 space-y-2">
+        {sections.map((section, index) => (
+          <motion.article
+            key={section.id}
+            className="rounded-lg border bg-background p-3"
+            initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+            animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+            transition={
+              shouldReduceMotion
+                ? undefined
+                : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+            }
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">{section.title}</h3>
+                  <span
+                    className={cn("rounded px-1.5 py-0.5 text-[11px]", statusClass(section.status))}
+                  >
+                    {section.status ?? "draft"}
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground text-pretty">{section.description}</p>
+              </div>
+
+              <button
+                type="button"
+                className="inline-flex h-8 items-center rounded-md border border-input bg-background px-2 text-xs font-medium transition-colors hover:bg-accent"
+                onClick={() => onOpenSection?.(section)}
+              >
+                Open section
+              </button>
+            </div>
+
+            {section.items && section.items.length > 0 ? (
+              <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+                {section.items.map((item) => (
+                  <div
+                    key={`${section.id}-${item.label}`}
+                    className="rounded border bg-muted/40 px-2 py-1"
+                  >
+                    <dt className="text-[11px] text-muted-foreground">{item.label}</dt>
+                    <dd className="truncate text-xs text-foreground">{item.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </motion.article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/blocks/src/saas-team-roster.tsx
+++ b/packages/blocks/src/saas-team-roster.tsx
@@ -1,0 +1,162 @@
+import { motion, useReducedMotion } from "motion/react";
+import * as React from "react";
+
+export type SaasMemberStatus = "active" | "invited" | "suspended";
+
+export type SaasTeamMember = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: SaasMemberStatus;
+  avatarFallback?: string;
+  lastSeen?: string;
+  mfaEnabled?: boolean;
+};
+
+type SaasTeamRosterProps = React.ComponentPropsWithoutRef<"section"> & {
+  title?: string;
+  description?: string;
+  members: SaasTeamMember[];
+  maxVisible?: number;
+  onInviteClick?: () => void;
+  onMemberClick?: (member: SaasTeamMember) => void;
+};
+
+function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function statusBadgeClass(status: SaasMemberStatus) {
+  if (status === "active") {
+    return "bg-emerald-500/10 text-emerald-700";
+  }
+  if (status === "invited") {
+    return "bg-amber-500/10 text-amber-700";
+  }
+  return "bg-destructive/10 text-destructive";
+}
+
+function initials(name: string, fallback?: string) {
+  if (fallback) {
+    return fallback;
+  }
+
+  const chunks = name
+    .split(" ")
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+
+  return chunks.map((chunk) => chunk[0]?.toUpperCase() ?? "").join("") || "U";
+}
+
+export function SaasTeamRoster({
+  title = "Team Access",
+  description = "Monitor team seats, security status, and member lifecycle in one panel.",
+  members,
+  maxVisible = 6,
+  onInviteClick,
+  onMemberClick,
+  className,
+  ...props
+}: SaasTeamRosterProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  const visibleMembers = React.useMemo(
+    () => members.slice(0, Math.max(1, maxVisible)),
+    [maxVisible, members],
+  );
+
+  const summary = React.useMemo(() => {
+    const active = members.filter((member) => member.status === "active").length;
+    const invited = members.filter((member) => member.status === "invited").length;
+    const suspended = members.filter((member) => member.status === "suspended").length;
+    const mfa = members.filter((member) => member.mfaEnabled).length;
+
+    return { active, invited, suspended, mfa };
+  }, [members]);
+
+  return (
+    <section className={cn("rounded-xl border bg-card p-4", className)} {...props}>
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-balance">{title}</h2>
+          <p className="text-sm text-muted-foreground text-pretty">{description}</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-9 items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium transition-colors hover:bg-accent"
+          onClick={onInviteClick}
+        >
+          Invite teammate
+        </button>
+      </header>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryCard label="Active" value={summary.active} />
+        <SummaryCard label="Invited" value={summary.invited} />
+        <SummaryCard label="Suspended" value={summary.suspended} />
+        <SummaryCard label="MFA Enabled" value={summary.mfa} />
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {visibleMembers.map((member, index) => (
+          <motion.button
+            key={member.id}
+            type="button"
+            onClick={() => {
+              onMemberClick?.(member);
+            }}
+            className="flex w-full items-center gap-3 rounded-lg border bg-background px-3 py-2 text-left transition-colors hover:bg-accent/60"
+            initial={shouldReduceMotion ? undefined : { opacity: 0, y: 6 }}
+            animate={shouldReduceMotion ? undefined : { opacity: 1, y: 0 }}
+            transition={
+              shouldReduceMotion
+                ? undefined
+                : { duration: 0.2, ease: "easeOut", delay: index * 0.02 }
+            }
+            whileHover={shouldReduceMotion ? undefined : { y: -1 }}
+          >
+            <span className="inline-flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+              {initials(member.name, member.avatarFallback)}
+            </span>
+
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium">{member.name}</span>
+                <span
+                  className={cn(
+                    "rounded px-1.5 py-0.5 text-[11px]",
+                    statusBadgeClass(member.status),
+                  )}
+                >
+                  {member.status}
+                </span>
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">{member.email}</span>
+            </span>
+
+            <span className="text-right">
+              <span className="block text-xs text-foreground">{member.role}</span>
+              {member.lastSeen ? (
+                <span className="block text-[11px] text-muted-foreground">
+                  Seen {member.lastSeen}
+                </span>
+              ) : null}
+            </span>
+          </motion.button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <article className="rounded-lg border bg-background px-3 py-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-base font-semibold tabular-nums">{value}</p>
+    </article>
+  );
+}

--- a/packages/blocks/src/stories/saas-audit-timeline.stories.jsx
+++ b/packages/blocks/src/stories/saas-audit-timeline.stories.jsx
@@ -1,0 +1,43 @@
+import { SaasAuditTimeline } from "../saas-audit-timeline";
+
+export default {
+  title: "Blocks/SaaS Audit Timeline",
+  component: SaasAuditTimeline,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    events: [
+      {
+        id: "a-1",
+        actor: "Elena Brooks",
+        action: "changed role for",
+        target: "nora@acme.com",
+        time: "Today 10:12",
+        severity: "warning",
+        metadata: [
+          { label: "Before", value: "Viewer" },
+          { label: "After", value: "Support" },
+        ],
+      },
+      {
+        id: "a-2",
+        actor: "System",
+        action: "revoked token for",
+        target: "Webhook Worker",
+        time: "Today 09:47",
+        severity: "critical",
+        metadata: [{ label: "Reason", value: "Leak signal from scanner" }],
+      },
+      {
+        id: "a-3",
+        actor: "Kai Lin",
+        action: "created workspace",
+        target: "EMEA Expansion",
+        time: "Yesterday 18:03",
+        severity: "info",
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-billing-overview.stories.jsx
+++ b/packages/blocks/src/stories/saas-billing-overview.stories.jsx
@@ -1,0 +1,29 @@
+import { SaasBillingOverview } from "../saas-billing-overview";
+
+export default {
+  title: "Blocks/SaaS Billing Overview",
+  component: SaasBillingOverview,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    planName: "Scale Annual",
+    monthlyPrice: 2490,
+    currency: "USD",
+    renewalDate: "Apr 14, 2026",
+    usage: [
+      { id: "members", label: "Members", used: 112, limit: 150 },
+      { id: "projects", label: "Projects", used: 43, limit: 80 },
+      { id: "api", label: "API calls", used: 734000, limit: 1000000 },
+      { id: "storage", label: "Storage", used: 612, limit: 1000, unit: "GB" },
+    ],
+    invoice: {
+      subtotal: 2490,
+      discount: -250,
+      tax: 179.2,
+      total: 2419.2,
+      currency: "USD",
+    },
+  },
+};

--- a/packages/blocks/src/stories/saas-command-center.stories.jsx
+++ b/packages/blocks/src/stories/saas-command-center.stories.jsx
@@ -1,0 +1,47 @@
+import { SaasCommandCenter } from "../saas-command-center";
+
+export default {
+  title: "Blocks/SaaS Command Center",
+  component: SaasCommandCenter,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    actions: [
+      {
+        id: "invite-member",
+        title: "Invite team member",
+        description: "Create invitation with role and workspace scope.",
+        group: "Team",
+        shortcut: "G I",
+      },
+      {
+        id: "pause-subscription",
+        title: "Pause subscription",
+        description: "Open billing controls for temporary suspension.",
+        group: "Billing",
+      },
+      {
+        id: "create-segment",
+        title: "Create customer segment",
+        description: "Define saved filters for lifecycle campaigns.",
+        group: "Growth",
+        shortcut: "G S",
+      },
+      {
+        id: "rotate-token",
+        title: "Rotate API token",
+        description: "Regenerate server token and copy new secret.",
+        group: "Security",
+        badge: "urgent",
+      },
+      {
+        id: "create-webhook",
+        title: "Create webhook endpoint",
+        description: "Publish event stream to your integration backend.",
+        group: "Integrations",
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-integrations-grid.stories.jsx
+++ b/packages/blocks/src/stories/saas-integrations-grid.stories.jsx
@@ -1,0 +1,38 @@
+import { SaasIntegrationsGrid } from "../saas-integrations-grid";
+
+export default {
+  title: "Blocks/SaaS Integrations Grid",
+  component: SaasIntegrationsGrid,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    integrations: [
+      {
+        id: "stripe",
+        name: "Stripe",
+        category: "Payments",
+        description: "Sync subscriptions, invoices, disputes, and payment intents.",
+        status: "connected",
+        metric: "Last sync 4 min ago",
+      },
+      {
+        id: "hubspot",
+        name: "HubSpot",
+        category: "CRM",
+        description: "Push account and lifecycle events into HubSpot objects.",
+        status: "available",
+        metric: "Not connected",
+      },
+      {
+        id: "slack",
+        name: "Slack",
+        category: "Alerts",
+        description: "Broadcast incidents and compliance events to channels.",
+        status: "beta",
+        metric: "Beta connector",
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-kpi-grid.stories.jsx
+++ b/packages/blocks/src/stories/saas-kpi-grid.stories.jsx
@@ -1,0 +1,49 @@
+import { SaasKpiGrid } from "../saas-kpi-grid";
+
+export default {
+  title: "Blocks/SaaS KPI Grid",
+  component: SaasKpiGrid,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    title: "Revenue & Product Health",
+    description: "High-signal metrics for PM, growth, and platform reviews.",
+    columns: 4,
+    metrics: [
+      {
+        id: "mrr",
+        label: "MRR",
+        value: "$128,420",
+        tone: "success",
+        trend: { value: "+11.4%", direction: "up", label: "vs last month" },
+        sparkline: [20, 23, 24, 26, 29, 30, 34],
+      },
+      {
+        id: "churn",
+        label: "Churn",
+        value: "2.8%",
+        tone: "warning",
+        trend: { value: "-0.4%", direction: "down", label: "monthly" },
+        sparkline: [8, 7, 7, 6, 5, 5, 4],
+      },
+      {
+        id: "ltv",
+        label: "LTV",
+        value: "$1,942",
+        tone: "default",
+        trend: { value: "+6.2%", direction: "up", label: "quarterly" },
+        sparkline: [13, 14, 15, 16, 15, 17, 18],
+      },
+      {
+        id: "nps",
+        label: "NPS",
+        value: "48",
+        tone: "success",
+        trend: { value: "+2", direction: "up", label: "rolling 30d" },
+        sparkline: [32, 34, 37, 39, 41, 45, 48],
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-notification-inbox.stories.jsx
+++ b/packages/blocks/src/stories/saas-notification-inbox.stories.jsx
@@ -1,0 +1,39 @@
+import { SaasNotificationInbox } from "../saas-notification-inbox";
+
+export default {
+  title: "Blocks/SaaS Notification Inbox",
+  component: SaasNotificationInbox,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    notifications: [
+      {
+        id: "n-1",
+        title: "Payment retry succeeded",
+        body: "Invoice INV-4012 was collected after retry sequence.",
+        category: "Billing",
+        time: "2 min ago",
+        priority: "normal",
+      },
+      {
+        id: "n-2",
+        title: "SAML policy update pending",
+        body: "Security policy changes require owner approval.",
+        category: "Security",
+        time: "18 min ago",
+        priority: "high",
+      },
+      {
+        id: "n-3",
+        title: "HubSpot sync completed",
+        body: "89 records were synced into your CRM connector.",
+        category: "Integrations",
+        time: "1 hour ago",
+        isRead: true,
+        priority: "low",
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-settings-sections.stories.jsx
+++ b/packages/blocks/src/stories/saas-settings-sections.stories.jsx
@@ -1,0 +1,40 @@
+import { SaasSettingsSections } from "../saas-settings-sections";
+
+export default {
+  title: "Blocks/SaaS Settings Sections",
+  component: SaasSettingsSections,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    sections: [
+      {
+        id: "identity",
+        title: "Identity & SSO",
+        description: "Domain verification, SAML, and SCIM provisioning controls.",
+        status: "attention",
+        items: [
+          { label: "Domain", value: "acme.com verified" },
+          { label: "SAML", value: "Okta (active)" },
+        ],
+      },
+      {
+        id: "security",
+        title: "Security baseline",
+        description: "Session policy, API secrets, and admin break-glass process.",
+        status: "complete",
+        items: [
+          { label: "MFA policy", value: "Required" },
+          { label: "Session timeout", value: "8 hours" },
+        ],
+      },
+      {
+        id: "notifications",
+        title: "Notification routing",
+        description: "Channel subscriptions for incidents, usage alerts, and billing events.",
+        status: "draft",
+      },
+    ],
+  },
+};

--- a/packages/blocks/src/stories/saas-team-roster.stories.jsx
+++ b/packages/blocks/src/stories/saas-team-roster.stories.jsx
@@ -1,0 +1,47 @@
+import { SaasTeamRoster } from "../saas-team-roster";
+
+export default {
+  title: "Blocks/SaaS Team Roster",
+  component: SaasTeamRoster,
+  tags: ["autodocs"],
+};
+
+export const Default = {
+  args: {
+    members: [
+      {
+        id: "u-1",
+        name: "Elena Brooks",
+        email: "elena@acme.com",
+        role: "Owner",
+        status: "active",
+        lastSeen: "3m ago",
+        mfaEnabled: true,
+      },
+      {
+        id: "u-2",
+        name: "Kai Lin",
+        email: "kai@acme.com",
+        role: "Admin",
+        status: "active",
+        lastSeen: "12m ago",
+        mfaEnabled: true,
+      },
+      {
+        id: "u-3",
+        name: "Nora Singh",
+        email: "nora@acme.com",
+        role: "Support",
+        status: "invited",
+      },
+      {
+        id: "u-4",
+        name: "Milo Carter",
+        email: "milo@acme.com",
+        role: "Analyst",
+        status: "suspended",
+        lastSeen: "2d ago",
+      },
+    ],
+  },
+};

--- a/registry.json
+++ b/registry.json
@@ -105,6 +105,166 @@
     },
     {
       "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-audit-timeline",
+      "type": "registry:block",
+      "title": "SaaS Audit Timeline",
+      "description": "Chronological audit event timeline for security and compliance visibility.",
+      "meta": {
+        "category": "security",
+        "a11y": "Ordered timeline semantics and contrast-safe severity indicators."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-audit-timeline.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-audit-timeline.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-billing-overview",
+      "type": "registry:block",
+      "title": "SaaS Billing Overview",
+      "description": "Plan, invoice, and usage overview panel for subscription SaaS admin consoles.",
+      "meta": {
+        "category": "billing",
+        "a11y": "Readable billing summary and usage progress with text alternatives."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-billing-overview.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-billing-overview.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-command-center",
+      "type": "registry:block",
+      "title": "SaaS Command Center",
+      "description": "Searchable command launcher for common backoffice actions and admin workflows.",
+      "meta": {
+        "category": "operations",
+        "a11y": "Keyboard-focusable command buttons and labeled command search field."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-command-center.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-command-center.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-integrations-grid",
+      "type": "registry:block",
+      "title": "SaaS Integrations Grid",
+      "description": "Integration catalog cards for connecting and configuring SaaS ecosystem tools.",
+      "meta": {
+        "category": "integrations",
+        "a11y": "Clear action buttons and text labels for integration states."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-integrations-grid.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-integrations-grid.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-kpi-grid",
+      "type": "registry:block",
+      "title": "SaaS KPI Grid",
+      "description": "Analytics KPI cards for SaaS dashboards with trend indicators and sparklines.",
+      "meta": {
+        "category": "analytics",
+        "a11y": "Semantic section headings and numeric values with tabular alignment."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-kpi-grid.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-kpi-grid.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-notification-inbox",
+      "type": "registry:block",
+      "title": "SaaS Notification Inbox",
+      "description": "Filtered operations inbox for SaaS notifications, incidents, and billing events.",
+      "meta": {
+        "category": "operations",
+        "a11y": "Filter controls and clear read state labels for notification triage."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-notification-inbox.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-notification-inbox.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-settings-sections",
+      "type": "registry:block",
+      "title": "SaaS Settings Sections",
+      "description": "Structured settings overview cards for identity, security, and workspace configuration.",
+      "meta": {
+        "category": "settings",
+        "a11y": "Section labels and status indicators with keyboard-accessible actions."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-settings-sections.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-settings-sections.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+      "name": "saas-team-roster",
+      "type": "registry:block",
+      "title": "SaaS Team Roster",
+      "description": "Team access roster for member lifecycle, role, and security coverage.",
+      "meta": {
+        "category": "team-management",
+        "a11y": "Accessible team actions and status labels for user lifecycle state."
+      },
+      "dependencies": ["motion"],
+      "registryDependencies": [],
+      "files": [
+        {
+          "path": "packages/blocks/src/saas-team-roster.tsx",
+          "type": "registry:component",
+          "target": "components/blocks/saas-team-roster.tsx"
+        }
+      ]
+    },
+    {
+      "$schema": "https://ui.shadcn.com/schema/registry-item.json",
       "name": "sidebar-navigation",
       "type": "registry:block",
       "title": "Sidebar Navigation",

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -8,6 +8,14 @@ const SOURCE_FILES = [
   "cta-banner.tsx",
   "data-table.tsx",
   "hero-split.tsx",
+  "saas-audit-timeline.tsx",
+  "saas-billing-overview.tsx",
+  "saas-command-center.tsx",
+  "saas-integrations-grid.tsx",
+  "saas-kpi-grid.tsx",
+  "saas-notification-inbox.tsx",
+  "saas-settings-sections.tsx",
+  "saas-team-roster.tsx",
   "sidebar-navigation.tsx",
 ];
 


### PR DESCRIPTION
## Summary
- add a comprehensive SaaS backoffice/admin block suite aligned with shadcn design language
- add 8 new reusable blocks with motion/react interactions and performance-safe animation patterns
- add Storybook stories and shadcn registry manifests for each new block
- add architecture/design research doc for SaaS block system composition
- update package exports, registry root manifest, and typecheck baseline

## New Blocks
- saas-kpi-grid
- saas-command-center
- saas-billing-overview
- saas-team-roster
- saas-notification-inbox
- saas-audit-timeline
- saas-integrations-grid
- saas-settings-sections

## Validation
- pnpm run format
- pnpm run check
- pnpm run visual:test

Closes #41
